### PR TITLE
Fixed issue with Cobra unmarshalling JSON and inadvertently escaping URL characters

### DIFF
--- a/steps/websteps/navigation_steps.go
+++ b/steps/websteps/navigation_steps.go
@@ -2,6 +2,7 @@ package websteps
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/cbush06/kosher/steps/steputils"
 )
@@ -10,17 +11,20 @@ import (
 func iAmOnThePage(s *steputils.StepUtils) func(string) error {
 	return func(pageName string) error {
 		var (
-			url string
-			err error
+			pageURL string
+			err     error
 		)
 
-		if url, err = s.ResolvePage(pageName); err != nil {
+		if pageURL, err = s.ResolvePage(pageName); err != nil {
 			return fmt.Errorf("error encountered while resolving page URL: %s", err)
-		} else if len(url) < 1 {
+		} else if len(pageURL) < 1 {
 			return fmt.Errorf("no page found for name [%s]", pageName)
 		}
 
-		if err = s.Page.Navigate(url); err != nil {
+		unescapedURL, _ := url.PathUnescape(pageURL)
+		fmt.Println("URL: " + unescapedURL)
+
+		if err = s.Page.Navigate(unescapedURL); err != nil {
 			return fmt.Errorf("failed to load page [%s]: %s", pageName, err)
 		}
 		return nil

--- a/test/results/results.html
+++ b/test/results/results.html
@@ -31,7 +31,7 @@
                         <h3>Kosher Test Results</h2>
                     </div>
                     <div class="col-sm ml-auto text-right">
-                        <h3>Friday, 08-Mar-19 21:09:06 EST</h2>
+                        <h3>Monday, 11-Mar-19 22:15:33 EDT</h2>
                     </div>
                 </div>
             </div>
@@ -61,7 +61,7 @@
 						<th>OS:</th>
 						<td>linux (amd64)</td>
 						<th>Total Run Time:</th>
-						<td>6.95834951s</td>
+						<td>6.951317418s</td>
                 </tbody>
             </table>
 		</div>
@@ -99,7 +99,7 @@ a form, verfiy that the correct navigations take place.</pre></p>
 									</td>
                                     </td>
                                     <td style="width: 10%;">
-                                        2.44s
+                                        2.56s
                                     </td>
                                 </tr>
                                 
@@ -110,7 +110,7 @@ a form, verfiy that the correct navigations take place.</pre></p>
 									</td>
                                     </td>
                                     <td style="width: 10%;">
-                                        0.13s
+                                        0.10s
                                     </td>
                                 </tr>
                                 
@@ -121,7 +121,7 @@ a form, verfiy that the correct navigations take place.</pre></p>
 									</td>
                                     </td>
                                     <td style="width: 10%;">
-                                        0.18s
+                                        0.19s
                                     </td>
                                 </tr>
                                 
@@ -132,7 +132,7 @@ a form, verfiy that the correct navigations take place.</pre></p>
 									</td>
                                     </td>
                                     <td style="width: 10%;">
-                                        0.95s
+                                        0.94s
                                     </td>
                                 </tr>
                                 
@@ -143,7 +143,7 @@ a form, verfiy that the correct navigations take place.</pre></p>
 									</td>
                                     </td>
                                     <td style="width: 10%;">
-                                        0.00s
+                                        0.02s
                                     </td>
                                 </tr>
                                 
@@ -172,7 +172,7 @@ a form, verfiy that the correct navigations take place.</pre></p>
 									</td>
                                     </td>
                                     <td style="width: 10%;">
-                                        0.16s
+                                        0.13s
                                     </td>
                                 </tr>
                                 
@@ -194,7 +194,7 @@ a form, verfiy that the correct navigations take place.</pre></p>
 									</td>
                                     </td>
                                     <td style="width: 10%;">
-                                        0.22s
+                                        0.19s
                                     </td>
                                 </tr>
                                 
@@ -205,7 +205,7 @@ a form, verfiy that the correct navigations take place.</pre></p>
 									</td>
                                     </td>
                                     <td style="width: 10%;">
-                                        0.37s
+                                        0.34s
                                     </td>
                                 </tr>
                                 
@@ -245,7 +245,7 @@ a form, verfiy that the correct navigations take place.</pre></p>
 									</td>
                                     </td>
                                     <td style="width: 10%;">
-                                        0.16s
+                                        0.15s
                                     </td>
                                 </tr>
                                 
@@ -267,7 +267,7 @@ a form, verfiy that the correct navigations take place.</pre></p>
 									</td>
                                     </td>
                                     <td style="width: 10%;">
-                                        0.93s
+                                        0.88s
                                     </td>
                                 </tr>
                                 
@@ -289,7 +289,7 @@ a form, verfiy that the correct navigations take place.</pre></p>
 									</td>
                                     </td>
                                     <td style="width: 10%;">
-                                        0.18s
+                                        0.21s
                                     </td>
                                 </tr>
                                 
@@ -311,7 +311,7 @@ a form, verfiy that the correct navigations take place.</pre></p>
 									</td>
                                     </td>
                                     <td style="width: 10%;">
-                                        0.00s
+                                        0.01s
                                     </td>
                                 </tr>
                                 

--- a/test/results/results.json
+++ b/test/results/results.json
@@ -20,11 +20,11 @@
                         "name": "I go to the \"table-search\" page",
                         "line": 7,
                         "match": {
-                            "location": "navigation_steps.go:11"
+                            "location": "navigation_steps.go:12"
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 2435623068
+                            "duration": 2556327586
                         }
                     },
                     {
@@ -36,7 +36,7 @@
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 128706640
+                            "duration": 103859574
                         }
                     },
                     {
@@ -44,11 +44,11 @@
                         "name": "I click the \"Date pickers\" link",
                         "line": 13,
                         "match": {
-                            "location": "form_steps.go:322"
+                            "location": "form_steps.go:307"
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 175812580
+                            "duration": 191586482
                         }
                     },
                     {
@@ -56,11 +56,11 @@
                         "name": "I click the \"Bootstrap Date Picker\" link",
                         "line": 14,
                         "match": {
-                            "location": "form_steps.go:322"
+                            "location": "form_steps.go:307"
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 954473192
+                            "duration": 936613971
                         }
                     },
                     {
@@ -72,7 +72,7 @@
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 4891489
+                            "duration": 24805428
                         }
                     }
                 ]
@@ -90,11 +90,11 @@
                         "name": "I go to the \"table-search\" page",
                         "line": 7,
                         "match": {
-                            "location": "navigation_steps.go:11"
+                            "location": "navigation_steps.go:12"
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 163556475
+                            "duration": 126888455
                         }
                     },
                     {
@@ -106,7 +106,7 @@
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 107583869
+                            "duration": 107455888
                         }
                     },
                     {
@@ -114,11 +114,11 @@
                         "name": "I click the \"Date pickers\" link",
                         "line": 20,
                         "match": {
-                            "location": "form_steps.go:322"
+                            "location": "form_steps.go:307"
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 220182695
+                            "duration": 192741927
                         }
                     },
                     {
@@ -126,11 +126,11 @@
                         "name": "I click the \"Bootstrap Date Picker\" link",
                         "line": 21,
                         "match": {
-                            "location": "form_steps.go:322"
+                            "location": "form_steps.go:307"
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 367662570
+                            "duration": 339253750
                         }
                     },
                     {
@@ -142,7 +142,7 @@
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 6169461
+                            "duration": 7243927
                         }
                     }
                 ]
@@ -160,11 +160,11 @@
                         "name": "I go to the \"table-search\" page",
                         "line": 7,
                         "match": {
-                            "location": "navigation_steps.go:11"
+                            "location": "navigation_steps.go:12"
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 157212896
+                            "duration": 146614140
                         }
                     },
                     {
@@ -176,7 +176,7 @@
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 117385741
+                            "duration": 116661130
                         }
                     },
                     {
@@ -184,11 +184,11 @@
                         "name": "I am on the \"js-popup\" page",
                         "line": 27,
                         "match": {
-                            "location": "navigation_steps.go:11"
+                            "location": "navigation_steps.go:12"
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 932731293
+                            "duration": 882109822
                         }
                     },
                     {
@@ -200,7 +200,7 @@
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 2517622
+                            "duration": 4706958
                         }
                     },
                     {
@@ -208,11 +208,11 @@
                         "name": "I click the first instance of \"Click me!\"",
                         "line": 29,
                         "match": {
-                            "location": "form_steps.go:328"
+                            "location": "form_steps.go:313"
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 177863312
+                            "duration": 206484511
                         }
                     },
                     {
@@ -224,7 +224,7 @@
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 1001867205
+                            "duration": 1001100745
                         }
                     },
                     {
@@ -236,7 +236,7 @@
                         },
                         "result": {
                             "status": "passed",
-                            "duration": 4109402
+                            "duration": 6863124
                         }
                     }
                 ]


### PR DESCRIPTION
Found the issue was Golang auto-escapes characters when unmarshalling JSON (for some weird reason???). Solution was to use url.PathUnescape(...) on page URLs before commanding the browser to navigate.